### PR TITLE
ProfileFixesDone

### DIFF
--- a/api/src/controllers/privacy.js
+++ b/api/src/controllers/privacy.js
@@ -2,13 +2,22 @@ const { Privacy, User } = require("../db.js");
 
 module.exports = {
   async setPrivacy(req, res) {
-    const { email, onLineStatus,gitHub,linkedIn, userId } = req.body
+    const { emailP, onLineStatus,gitHub,linkedIn, userId } = req.body
     if (!userId) {
-        res.status(400).send({ message: 'No se ha identificado el usuario', status: 400 })
+        return res.status(400).send({ message: 'No se ha identificado el usuario', status: 400 })
+    }
+    let current = await Privacy.findOne({
+      where:{
+        userId: userId
+      }
+    })
+    if(current){
+      console.log(current)
+      return res.status(204).send(current)
     }
     try {
         const privacyStatus = await Privacy.create({
-          emailP: email,
+          emailP: emailP,
           onLineStatus: onLineStatus,
           gitHub: gitHub,
           linkedIn:linkedIn,
@@ -43,7 +52,7 @@ module.exports = {
         },
 
     async changePrivacy(req, res) {
-        const { userId, email, onLineStatus, gitHub, linkedIn} = req.body
+        const { userId, emailP, onLineStatus, gitHub, linkedIn} = req.body
         if (!userId) {
             res.status(400).send({ message: 'Faltan campos obligatorios', status: 400 })
         }
@@ -53,7 +62,7 @@ module.exports = {
                   userId: userId
               }
             })
-            userPrivacy.emailP = email || userPrivacy.emailP
+            userPrivacy.emailP = emailP || userPrivacy.emailP
             userPrivacy.onLineStatus = onLineStatus || userPrivacy.onLineStatus
             userPrivacy.gitHub = gitHub || userPrivacy.gitHub
             userPrivacy.linkedIn = linkedIn || userPrivacy.linkedIn


### PR DESCRIPTION
Forma de usar el componente en la demo:

- Ir a la ruta de login para que se cargue el admin
- Correr el seed para crear los usuarios
- Entrar al perfil de un alumno. Ej: cesar@soyhenry.com / cecilia@soyhenry.com
- Agregar GitHub y LinkedIn (linkedin debe ser una dirección)
- Pinchar sobre usuario de github para mostrar la información que trae
- Establecer restricciones a los campos de la configuración de privacidad 
    * Dejar 2 campos visibles para toda la comunidad
    * Dejar un campo solo para el equipo de henry
    * Dejar un campo para henry y los pm
- Entrar a la página con el otro alumno (cecilia o cesar)
- Buscar al alumno anterior
- Agregar datos de github y linkedin
- Salir y entrar como administrador
- Buscar a ambos (llegan juntos al buscar por "ce" en el campo nombre
- Pinchar sobre los enlaces de gitHub y LinkedIn (estos abren una nueva pestaña)

No alcancé a hacer lo del upgrade a los usuarios desde la tabla, pero después de la demo lo agrego ya funcionando.